### PR TITLE
Set British English as default locale

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,8 @@ module UlabWebsite
     # Serve static assets
     config.serve_static_assets = true
 
+    config.i18n.default_locale = :'en-GB'
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require 'rails/all'
@@ -7,7 +9,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module UlabWebsite
-  class Application < Rails::Application
+  class Application < Rails::Application # :nodoc:
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
@@ -16,7 +18,8 @@ module UlabWebsite
 
     config.i18n.default_locale = :'en-GB'
 
-    # Settings in config/environments/* take precedence over those specified here.
+    # Settings in config/environments/* take precedence over those specified
+    # here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.

--- a/db/migrate/20181211170042_translate_british_english_pages.rb
+++ b/db/migrate/20181211170042_translate_british_english_pages.rb
@@ -2,6 +2,7 @@
 
 class TranslateBritishEnglishPages < ActiveRecord::Migration[5.2] # :nodoc:
   def up
+    I18n.default_locale = :en
     Rake::Task[:'ulab_website:create_translations'].invoke
   end
 

--- a/db/migrate/20181211202925_set_default_locale.rb
+++ b/db/migrate/20181211202925_set_default_locale.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class SetDefaultLocale < ActiveRecord::Migration[5.2] # :nodoc:
+  def change
+    I18n.default_locale = :'en-GB'
+    Rake::Task[:'spina:update_translations'].invoke
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_11_170042) do
+ActiveRecord::Schema.define(version: 2018_12_11_202925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This PR adds additional migrations to support moving to a new default locale. Resolves #14.