### PR TITLE
Add sponsor logos to conference pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,4 +373,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/assets/stylesheets/ulab_conference/application.sass
+++ b/app/assets/stylesheets/ulab_conference/application.sass
@@ -21,8 +21,11 @@ html
     margin-top: unset
   height: 100%
   a
-    text-decoration: unset
     color: unset
+    &.button
+      text-decoration: unset
+  article > a
+    text-decoration: unset
   body
     height: 100%
     display: flex

--- a/app/assets/stylesheets/ulab_conference/breadcrumbs.sass
+++ b/app/assets/stylesheets/ulab_conference/breadcrumbs.sass
@@ -8,17 +8,6 @@ nav
     li
       display: inline
       box-sizing: border-box
-      & a
-        display: inline-block
-        padding: 10px 15px
-        border: 1px solid #ccc
-        border-radius: 23px
-        &:hover
-          color: $primary-color
-          border-color: $primary-color
-        &:active
-          background: $primary-color
-          color: #fff
     .divider
       background: url(asset-path('spina/divider.svg'))
       color: $primary-color

--- a/app/assets/stylesheets/ulab_conference/main.sass
+++ b/app/assets/stylesheets/ulab_conference/main.sass
@@ -35,8 +35,9 @@ main
       kerning: auto
       stretch: semi-expanded
     line-height: 100%
-  & header + *
-    margin-top: 16px
+  &, header
+    *:not(:first-child)
+      margin-top: 16px
   ul.content-list
     list-style: none
     padding: unset

--- a/app/views/layouts/ulab_conference/application.html.haml
+++ b/app/views/layouts/ulab_conference/application.html.haml
@@ -6,7 +6,7 @@
           %ol<
             - current_page.ancestors.each do |ancestor|
               %li
-                = link_to ancestor.menu_title, ancestor.materialized_path
+                = link_to ancestor.menu_title, ancestor.materialized_path, class: 'button'
               .divider
             %li= current_page.menu_title
       - if current_account.has_content? :current_conference_alert

--- a/app/views/ulab_conference/pages/conference.haml
+++ b/app/views/ulab_conference/pages/conference.haml
@@ -14,6 +14,16 @@
 = link_to conferences_conference_url(conference, protocol: :webcal, format: :ics), class: :button do
   Subscribe to conference calendar
 
+- if has_content? :sponsors
+  - unless content(:sponsors).structure_items.empty?
+    %h2 Sponsors
+    %ul.content-list
+      - content(:sponsors).structure_items.each do |sponsor|
+        %li
+          - if sponsor.has_content?(:logo) && sponsor.has_content?(:website)
+            = link_to sponsor.content(:website) do
+              = image_tag variant(sponsor.content(:logo).file, resize: "600x600"), width: 150, draggable: false, alt: sponsor.content(:name)
+
 - if has_content? :gallery
   = render "#{current_theme.name}/shared/gallery"
 

--- a/config/initializers/themes/ulab_conference.rb
+++ b/config/initializers/themes/ulab_conference.rb
@@ -52,6 +52,10 @@
     name: 'committee_bios',
     title: 'Committee bios',
     partable_type: 'Spina::Structure'
+  }, {
+    name: 'sponsors',
+    title: 'Sponsors',
+    partable_type: 'Spina::Structure'
   }]
 
   theme.layout_parts = [{
@@ -159,6 +163,21 @@
       title: 'Twitter profile',
       partable_type: 'Spina::Conferences::UrlPart'
     }]
+  }, {
+    name: 'sponsors',
+    structure_parts: [{
+      name: 'name',
+      title: 'Name',
+      partable_type: 'Spina::Line'
+    }, {
+      name: 'logo',
+      title: 'Logo',
+      partable_type: 'Spina::Image'
+    }, {
+      name: 'website',
+      title: 'Website',
+      partable_type: 'Spina::Conferences::UrlPart'
+    }]
   }]
 
   theme.view_templates = [{
@@ -180,7 +199,7 @@
     title: 'Conference',
     description: 'Contains information and content for a conference',
     page_parts: %w[text submission_url submission_date submission_text
-                   gallery socials meetings]
+                   gallery socials meetings sponsors]
   }, {
     name: 'presentation',
     title: 'Presentation',


### PR DESCRIPTION
This PR allows sponsor logos to be added to conference pages, and fixes a few UI bugs.