### PR TITLE
Fix styling for links and breadcrumbs

### DIFF
--- a/app/assets/stylesheets/ulab_conference/application.sass
+++ b/app/assets/stylesheets/ulab_conference/application.sass
@@ -24,8 +24,6 @@ html
     color: unset
     &.button
       text-decoration: unset
-  article > a
-    text-decoration: unset
   body
     height: 100%
     display: flex

--- a/app/assets/stylesheets/ulab_conference/article.sass
+++ b/app/assets/stylesheets/ulab_conference/article.sass
@@ -2,6 +2,7 @@ article:not(.no-link)
   &:not(:first-child)
     margin-top: -1px
   & > a
+    text-decoration: unset
     border:
       top: 1px solid #ccc
       bottom: 1px solid #ccc

--- a/app/assets/stylesheets/ulab_conference/breadcrumbs.sass
+++ b/app/assets/stylesheets/ulab_conference/breadcrumbs.sass
@@ -6,7 +6,7 @@ nav
       size: 20px
       weight: 300
     li
-      display: inline
+      display: inline-block
       box-sizing: border-box
     .divider
       background: url(asset-path('spina/divider.svg'))

--- a/app/assets/stylesheets/ulab_conference/nav.sass
+++ b/app/assets/stylesheets/ulab_conference/nav.sass
@@ -16,6 +16,7 @@
       &:hover
         z-index: 2
       a
+        text-decoration: unset
         display: block
         padding: 12px $padding
         border:


### PR DESCRIPTION
This PR removes underlining from navigation links, and makes breadcrumbs display properly.