### PR TITLE
Enlarge text

### DIFF
--- a/app/views/ulab_conference/committee_bios/_committee_bio.html.haml
+++ b/app/views/ulab_conference/committee_bios/_committee_bio.html.haml
@@ -10,4 +10,4 @@
         .BtnGroup.flex-shrink-0.mt-1.mt-md-0.ml-md-1{ role: :group, aria: { label: 'Contact buttons' } }
           = link_to 'Twitter', committee_bio.content(:twitter_profile), class: %w[button btn BtnGroup-item], role: :button if committee_bio.has_content? :twitter_profile
           = link_to 'Facebook', committee_bio.content(:facebook_profile), class: %w[button btn BtnGroup-item], role: :button if committee_bio.has_content? :facebook_profile
-    .text-small.text-gray-light= committee_bio.content(:bio).try(:html_safe) if committee_bio.has_content? :bio
+    .text-gray-light= committee_bio.content(:bio).try(:html_safe) if committee_bio.has_content? :bio

--- a/app/views/ulab_conference/partner_societies/_partner_society.html.haml
+++ b/app/views/ulab_conference/partner_societies/_partner_society.html.haml
@@ -10,5 +10,5 @@
         = link_to "mailto:#{partner_society.content(:email_address)}", class: %w[btn BtnGroup-item], role: :button do
           = octicon 'mail'
           Email
-  .text-small.text-gray-light= partner_society.content(:description).try(:html_safe) if partner_society.has_content? :description
+  .text-gray-light= partner_society.content(:description).try(:html_safe) if partner_society.has_content? :description
 = responsive_image_tag partner_society.content(:logo).file, variant: { resize_to_limit: [200, 150] }, draggable: false, class: 'flex-shrink-0' if partner_society.has_content? :logo


### PR DESCRIPTION
Committee bios and partner society descriptions had excessively small text. In future `.text-small` should be used only when the body is both unimportant and likely quite short.